### PR TITLE
remove dependency from /perm/sp3c/DE_330-verif-scripts in point_verif…

### DIFF
--- a/R/point_verif/point_verif.R
+++ b/R/point_verif/point_verif.R
@@ -16,9 +16,7 @@ library(here)
 # conf_det_scores.R
 
 ###
-#source(Sys.getenv('CONFIG_R'))
-CONFIG_R='/perm/sp3c/DE_330-verif-scripts/config/config_atos.R'
-source(CONFIG_R)
+source(Sys.getenv('CONFIG_R'))
 ###
 parser <- ArgumentParser()
 

--- a/R/point_verif/point_verif_local.R
+++ b/R/point_verif/point_verif_local.R
@@ -17,16 +17,10 @@ library(pracma) # For logseq
 library(mapproj)
 
 ###
-CONFIG_R='/perm/sp3c/DE_330-verif-scripts/config/config_atos.R'
-#source(Sys.getenv('CONFIG_R'))
-#source(here("R/visualization/fn_plot_point_verif.R"))
-#source(here("R/visualization/fn_plot_aux_scores.R"))
-#source(here("R/visualization/fn_plot_helpers.R"))
-source(CONFIG_R)
-source(here("/perm/sp3c/DE_330-verif-scripts/R/visualization/fn_plot_point_verif.R"))
-source(here("/perm/sp3c/DE_330-verif-scripts/R/visualization/fn_plot_aux_scores.R"))
-source(here("/perm/sp3c/DE_330-verif-scripts/R/visualization/fn_plot_helpers.R"))
-
+source(Sys.getenv('CONFIG_R'))
+source(here("R/visualization/fn_plot_point_verif.R"))
+source(here("R/visualization/fn_plot_aux_scores.R"))
+source(here("R/visualization/fn_plot_helpers.R"))
 ###
 parser <- ArgumentParser()
 


### PR DESCRIPTION
@svianaj, I guess the dependency from  '/perm/sp3c/DE_330-verif-scripts' should be removed from point_verif.R & point_verif_local.R

In this way, launching 'sbatch main.sh' from the user's location 'DE_330-verif-scripts', the user can properly point to right location of the scripts in 'DE_330-verif-scripts/R/point_verif'.

Without this change, I got permission denied to '/perm/sp3c/DE_330-verif-scripts' 